### PR TITLE
[sync] upstream inverse acceleration

### DIFF
--- a/benches/bn256_field.rs
+++ b/benches/bn256_field.rs
@@ -40,6 +40,9 @@ pub fn bench_bn256_field(c: &mut Criterion) {
     group.bench_function("bn256_fq_square", |bencher| {
         bencher.iter(|| black_box(&a).square())
     });
+    group.bench_function("bn256_fq_invert", |bencher| {
+        bencher.iter(|| black_box(&a).invert())
+    });
 }
 
 criterion_group!(benches, bench_bn256_field);

--- a/benches/bn256_field.rs
+++ b/benches/bn256_field.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use halo2curves::bn256::*;
-use halo2curves::ff::Field;
+use halo2curves::{bn256::*, ff::Field, legendre::Legendre};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
@@ -42,6 +41,12 @@ pub fn bench_bn256_field(c: &mut Criterion) {
     });
     group.bench_function("bn256_fq_invert", |bencher| {
         bencher.iter(|| black_box(&a).invert())
+    });
+    group.bench_function("bn256_fq_legendre", |bencher| {
+        bencher.iter(|| black_box(&a).legendre())
+    });
+    group.bench_function("bn256_fq_jacobi", |bencher| {
+        bencher.iter(|| black_box(&a).jacobi())
     });
 }
 

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -217,17 +217,10 @@ impl ff::Field for Fq {
         ff::helpers::sqrt_ratio_generic(num, div)
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow([
-            0x3c208c16d87cfd45,
-            0x97816a916871ca8d,
-            0xb85045b68181585d,
-            0x30644e72e131a029,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 }
 

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -231,17 +231,10 @@ impl ff::Field for Fr {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow([
-            0x43e1f593efffffff,
-            0x2833e84879b97091,
-            0xb85045b68181585d,
-            0x30644e72e131a029,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 
     fn sqrt(&self) -> CtOption<Self> {

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -24,6 +24,11 @@ macro_rules! field_common {
         $r2:ident,
         $r3:ident
     ) => {
+        /// Bernstein-Yang modular multiplicative inverter created for the modulus equal to
+        /// the characteristic of the field to invert positive integers in the Montgomery form.
+        const BYINVERTOR: $crate::ff_inverse::BYInverter<6> =
+            $crate::ff_inverse::BYInverter::<6>::new(&$modulus.0, &$r2.0);
+
         impl $field {
             /// Returns zero, the additive identity.
             #[inline]
@@ -35,6 +40,16 @@ macro_rules! field_common {
             #[inline]
             pub const fn one() -> $field {
                 $r
+            }
+
+            /// Returns the multiplicative inverse of the
+            /// element. If it is zero, the method fails.
+            pub fn invert(&self) -> CtOption<Self> {
+                if let Some(inverse) = BYINVERTOR.invert(&self.0) {
+                    CtOption::new(Self(inverse), Choice::from(1))
+                } else {
+                    CtOption::new(Self::zero(), Choice::from(0))
+                }
             }
 
             fn from_u512(limbs: [u64; 8]) -> $field {
@@ -339,6 +354,7 @@ macro_rules! field_common {
 macro_rules! field_arithmetic {
     ($field:ident, $modulus:ident, $inv:ident, $field_type:ident) => {
         field_specific!($field, $modulus, $inv, $field_type);
+
         impl $field {
             /// Doubles this field element.
             #[inline]

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -52,6 +52,12 @@ macro_rules! field_common {
                 }
             }
 
+            // Returns the Legendre symbol, where the numerator and denominator
+            // are the element and the characteristic of the field, respectively.
+            pub fn jacobi(&self) -> i64 {
+                $crate::ff_jacobi::jacobi::<5>(&self.0, &$modulus.0)
+            }
+
             fn from_u512(limbs: [u64; 8]) -> $field {
                 // We reduce an arbitrary 512-bit number by decomposing it into two 256-bit digits
                 // with the higher bits multiplied by 2^256. Thus, we perform two reductions
@@ -345,6 +351,28 @@ macro_rules! field_common {
                     writer.write_all(&limb.to_le_bytes())?;
                 }
                 Ok(())
+            }
+        }
+
+        #[test]
+        fn test_jacobi() {
+            use rand::SeedableRng;
+            use $crate::ff::Field;
+            use $crate::legendre::Legendre;
+            let mut rng = rand_xorshift::XorShiftRng::from_seed([
+                0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+                0xbc, 0xe5,
+            ]);
+            for _ in 0..100000 {
+                let e = $field::random(&mut rng);
+                assert_eq!(
+                    e.legendre(),
+                    match e.jacobi() {
+                        1 => $field::ONE,
+                        -1 => -$field::ONE,
+                        _ => $field::ZERO,
+                    }
+                );
             }
         }
     };

--- a/src/ff_inverse.rs
+++ b/src/ff_inverse.rs
@@ -1,0 +1,424 @@
+use core::cmp::PartialEq;
+use std::ops::{Add, Mul, Neg, Sub};
+
+/// Big signed (B * L)-bit integer type, whose variables store
+/// numbers in the two's complement code as arrays of B-bit chunks.
+/// The ordering of the chunks in these arrays is little-endian.
+/// The arithmetic operations for this type are wrapping ones.
+#[derive(Clone)]
+struct CInt<const B: usize, const L: usize>(pub [u64; L]);
+
+impl<const B: usize, const L: usize> CInt<B, L> {
+    /// Mask, in which the B lowest bits are 1 and only they
+    pub const MASK: u64 = u64::MAX >> (64 - B);
+
+    /// Representation of -1
+    pub const MINUS_ONE: Self = Self([Self::MASK; L]);
+
+    /// Representation of 0
+    pub const ZERO: Self = Self([0; L]);
+
+    /// Representation of 1
+    pub const ONE: Self = {
+        let mut data = [0; L];
+        data[0] = 1;
+        Self(data)
+    };
+
+    /// Returns the result of applying B-bit right
+    /// arithmetical shift to the current number
+    pub fn shift(&self) -> Self {
+        let mut data = [0; L];
+        if self.is_negative() {
+            data[L - 1] = Self::MASK;
+        }
+        data[..L - 1].copy_from_slice(&self.0[1..]);
+        Self(data)
+    }
+
+    /// Returns the lowest B bits of the current number
+    pub fn lowest(&self) -> u64 {
+        self.0[0]
+    }
+
+    /// Returns "true" iff the current number is negative
+    pub fn is_negative(&self) -> bool {
+        self.0[L - 1] > (Self::MASK >> 1)
+    }
+}
+
+impl<const B: usize, const L: usize> PartialEq for CInt<B, L> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<const B: usize, const L: usize> Add for &CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn add(self, other: Self) -> Self::Output {
+        let (mut data, mut carry) = ([0; L], 0);
+        for i in 0..L {
+            let sum = self.0[i] + other.0[i] + carry;
+            data[i] = sum & CInt::<B, L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B: usize, const L: usize> Add<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn add(self, other: &Self) -> Self::Output {
+        &self + other
+    }
+}
+
+impl<const B: usize, const L: usize> Add for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn add(self, other: Self) -> Self::Output {
+        &self + &other
+    }
+}
+
+impl<const B: usize, const L: usize> Sub for &CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn sub(self, other: Self) -> Self::Output {
+        // For the two's complement code the additive negation is the result of
+        // adding 1 to the bitwise inverted argument's representation. Thus, for
+        // any encoded integers x and y we have x - y = x + !y + 1, where "!" is
+        // the bitwise inversion and addition is done according to the rules of
+        // the code. The algorithm below uses this formula and is the modified
+        // addition algorithm, where the carry flag is initialized with 1 and
+        // the chunks of the second argument are bitwise inverted
+        let (mut data, mut carry) = ([0; L], 1);
+        for i in 0..L {
+            let sum = self.0[i] + (other.0[i] ^ CInt::<B, L>::MASK) + carry;
+            data[i] = sum & CInt::<B, L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B: usize, const L: usize> Sub<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn sub(self, other: &Self) -> Self::Output {
+        &self - other
+    }
+}
+
+impl<const B: usize, const L: usize> Sub for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn sub(self, other: Self) -> Self::Output {
+        &self - &other
+    }
+}
+
+impl<const B: usize, const L: usize> Neg for &CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn neg(self) -> Self::Output {
+        // For the two's complement code the additive negation is the result
+        // of adding 1 to the bitwise inverted argument's representation
+        let (mut data, mut carry) = ([0; L], 1);
+        for i in 0..L {
+            let sum = (self.0[i] ^ CInt::<B, L>::MASK) + carry;
+            data[i] = sum & CInt::<B, L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B: usize, const L: usize> Neg for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn neg(self) -> Self::Output {
+        -&self
+    }
+}
+
+impl<const B: usize, const L: usize> Mul for &CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn mul(self, other: Self) -> Self::Output {
+        let mut data = [0; L];
+        for i in 0..L {
+            let mut carry = 0;
+            for k in 0..(L - i) {
+                let sum = (data[i + k] as u128)
+                    + (carry as u128)
+                    + (self.0[i] as u128) * (other.0[k] as u128);
+                data[i + k] = sum as u64 & CInt::<B, L>::MASK;
+                carry = (sum >> B) as u64;
+            }
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B: usize, const L: usize> Mul<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn mul(self, other: &Self) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const B: usize, const L: usize> Mul for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn mul(self, other: Self) -> Self::Output {
+        &self * &other
+    }
+}
+
+impl<const B: usize, const L: usize> Mul<i64> for &CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn mul(self, other: i64) -> Self::Output {
+        let mut data = [0; L];
+        // If the short multiplicand is non-negative, the standard multiplication
+        // algorithm is performed. Otherwise, the product of the additively negated
+        // multiplicands is found as follows. Since for the two's complement code
+        // the additive negation is the result of adding 1 to the bitwise inverted
+        // argument's representation, for any encoded integers x and y we have
+        // x * y = (-x) * (-y) = (!x + 1) * (-y) = !x * (-y) + (-y),  where "!" is
+        // the bitwise inversion and arithmetic operations are performed according
+        // to the rules of the code. If the short multiplicand is negative, the
+        // algorithm below uses this formula by substituting the short multiplicand
+        // for y and turns into the modified standard multiplication algorithm,
+        // where the carry flag is initialized with the additively negated short
+        // multiplicand and the chunks of the long multiplicand are bitwise inverted
+        let (other, mut carry, mask) = if other < 0 {
+            (-other, -other as u64, CInt::<B, L>::MASK)
+        } else {
+            (other, 0, 0)
+        };
+        for i in 0..L {
+            let sum = (carry as u128) + ((self.0[i] ^ mask) as u128) * (other as u128);
+            data[i] = sum as u64 & CInt::<B, L>::MASK;
+            carry = (sum >> B) as u64;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B: usize, const L: usize> Mul<i64> for CInt<B, L> {
+    type Output = CInt<B, L>;
+    fn mul(self, other: i64) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const B: usize, const L: usize> Mul<&CInt<B, L>> for i64 {
+    type Output = CInt<B, L>;
+    fn mul(self, other: &CInt<B, L>) -> Self::Output {
+        other * self
+    }
+}
+
+impl<const B: usize, const L: usize> Mul<CInt<B, L>> for i64 {
+    type Output = CInt<B, L>;
+    fn mul(self, other: CInt<B, L>) -> Self::Output {
+        other * self
+    }
+}
+
+/// Type of the modular multiplicative inverter based on the Bernstein-Yang method.
+/// The inverter can be created for a specified modulus M and adjusting parameter A
+/// to compute the adjusted multiplicative inverses of positive integers, i.e. for
+/// computing (1 / x) * A (mod M) for a positive integer x.
+///
+/// The adjusting parameter allows computing the multiplicative inverses in the case of
+/// using the Montgomery representation for the input or the expected output. If R is
+/// the Montgomery factor, the multiplicative inverses in the appropriate representation
+/// can be computed provided that the value of A is chosen as follows:
+/// - A = 1, if both the input and the expected output are in the standard form
+/// - A = R^2 mod M, if both the input and the expected output are in the Montgomery form
+/// - A = R mod M, if either the input or the expected output is in the Montgomery form,
+/// but not both of them
+///
+/// The public methods of this type receive and return unsigned big integers as arrays of
+/// 64-bit chunks, the ordering of which is little-endian. Both the modulus and the integer
+/// to be inverted should not exceed 2 ^ (62 * L - 64)
+///
+/// For better understanding the implementation, the following resources are recommended:
+/// - D. Bernstein, B.-Y. Yang, "Fast constant-time gcd computation and modular inversion",
+/// https://gcd.cr.yp.to/safegcd-20190413.pdf
+/// - P. Wuille, "The safegcd implementation in libsecp256k1 explained",
+/// https://github.com/bitcoin-core/secp256k1/blob/master/doc/safegcd_implementation.md
+pub struct BYInverter<const L: usize> {
+    /// Modulus
+    modulus: CInt<62, L>,
+
+    /// Adjusting parameter
+    adjuster: CInt<62, L>,
+
+    /// Multiplicative inverse of the modulus modulo 2^62
+    inverse: i64,
+}
+
+/// Type of the Bernstein-Yang transition matrix multiplied by 2^62
+type Matrix = [[i64; 2]; 2];
+
+impl<const L: usize> BYInverter<L> {
+    /// Returns the Bernstein-Yang transition matrix multiplied by 2^62 and the new value
+    /// of the delta variable for the 62 basic steps of the Bernstein-Yang method, which
+    /// are to be performed sequentially for specified initial values of f, g and delta
+    fn jump(f: &CInt<62, L>, g: &CInt<62, L>, mut delta: i64) -> (i64, Matrix) {
+        let (mut steps, mut f, mut g) = (62, f.lowest() as i64, g.lowest() as i128);
+        let mut t: Matrix = [[1, 0], [0, 1]];
+
+        loop {
+            let zeros = steps.min(g.trailing_zeros() as i64);
+            (steps, delta, g) = (steps - zeros, delta + zeros, g >> zeros);
+            t[0] = [t[0][0] << zeros, t[0][1] << zeros];
+
+            if steps == 0 {
+                break;
+            }
+            if delta > 0 {
+                (delta, f, g) = (-delta, g as i64, -f as i128);
+                (t[0], t[1]) = (t[1], [-t[0][0], -t[0][1]]);
+            }
+
+            // The formula (3 * x) xor 28 = -1 / x (mod 32) for an odd integer x
+            // in the two's complement code has been derived from the formula
+            // (3 * x) xor 2 = 1 / x (mod 32) attributed to Peter Montgomery
+            let mask = (1 << steps.min(1 - delta).min(5)) - 1;
+            let w = (g as i64).wrapping_mul(f.wrapping_mul(3) ^ 28) & mask;
+
+            t[1] = [t[0][0] * w + t[1][0], t[0][1] * w + t[1][1]];
+            g += w as i128 * f as i128;
+        }
+
+        (delta, t)
+    }
+
+    /// Returns the updated values of the variables f and g for specified initial ones and Bernstein-Yang transition
+    /// matrix multiplied by 2^62. The returned vector is "matrix * (f, g)' / 2^62", where "'" is the transpose operator
+    fn fg(f: CInt<62, L>, g: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
+        (
+            (t[0][0] * &f + t[0][1] * &g).shift(),
+            (t[1][0] * &f + t[1][1] * &g).shift(),
+        )
+    }
+
+    /// Returns the updated values of the variables d and e for specified initial ones and Bernstein-Yang transition
+    /// matrix multiplied by 2^62. The returned vector is congruent modulo M to "matrix * (d, e)' / 2^62 (mod M)",
+    /// where M is the modulus the inverter was created for and "'" stands for the transpose operator. Both the input
+    /// and output values lie in the interval (-2 * M, M)
+    fn de(&self, d: CInt<62, L>, e: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
+        let mask = CInt::<62, L>::MASK as i64;
+        let mut md = t[0][0] * d.is_negative() as i64 + t[0][1] * e.is_negative() as i64;
+        let mut me = t[1][0] * d.is_negative() as i64 + t[1][1] * e.is_negative() as i64;
+
+        let cd = t[0][0]
+            .wrapping_mul(d.lowest() as i64)
+            .wrapping_add(t[0][1].wrapping_mul(e.lowest() as i64))
+            & mask;
+        let ce = t[1][0]
+            .wrapping_mul(d.lowest() as i64)
+            .wrapping_add(t[1][1].wrapping_mul(e.lowest() as i64))
+            & mask;
+
+        md -= (self.inverse.wrapping_mul(cd).wrapping_add(md)) & mask;
+        me -= (self.inverse.wrapping_mul(ce).wrapping_add(me)) & mask;
+
+        let cd = t[0][0] * &d + t[0][1] * &e + md * &self.modulus;
+        let ce = t[1][0] * &d + t[1][1] * &e + me * &self.modulus;
+
+        (cd.shift(), ce.shift())
+    }
+
+    /// Returns either "value (mod M)" or "-value (mod M)", where M is the modulus the
+    /// inverter was created for, depending on "negate", which determines the presence
+    /// of "-" in the used formula. The input integer lies in the interval (-2 * M, M)
+    fn norm(&self, mut value: CInt<62, L>, negate: bool) -> CInt<62, L> {
+        if value.is_negative() {
+            value = value + &self.modulus;
+        }
+
+        if negate {
+            value = -value;
+        }
+
+        if value.is_negative() {
+            value = value + &self.modulus;
+        }
+
+        value
+    }
+
+    /// Returns a big unsigned integer as an array of O-bit chunks, which is equal modulo
+    /// 2 ^ (O * S) to the input big unsigned integer stored as an array of I-bit chunks.
+    /// The ordering of the chunks in these arrays is little-endian
+    const fn convert<const I: usize, const O: usize, const S: usize>(input: &[u64]) -> [u64; S] {
+        // This function is defined because the method "min" of the usize type is not constant
+        const fn min(a: usize, b: usize) -> usize {
+            if a > b {
+                b
+            } else {
+                a
+            }
+        }
+
+        let (total, mut output, mut bits) = (min(input.len() * I, S * O), [0; S], 0);
+
+        while bits < total {
+            let (i, o) = (bits % I, bits % O);
+            output[bits / O] |= (input[bits / I] >> i) << o;
+            bits += min(I - i, O - o);
+        }
+
+        let mask = u64::MAX >> (64 - O);
+        let mut filled = total / O + if total % O > 0 { 1 } else { 0 };
+
+        while filled > 0 {
+            filled -= 1;
+            output[filled] &= mask;
+        }
+
+        output
+    }
+
+    /// Returns the multiplicative inverse of the argument modulo 2^62. The implementation is based
+    /// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two.
+    /// For better understanding the implementation, the following paper is recommended:
+    /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
+    /// https://arxiv.org/pdf/2204.04342.pdf
+    const fn inv(value: u64) -> i64 {
+        let x = value.wrapping_mul(3) ^ 2;
+        let y = 1u64.wrapping_sub(x.wrapping_mul(value));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        (x.wrapping_mul(y.wrapping_add(1)) & CInt::<62, L>::MASK) as i64
+    }
+
+    /// Creates the inverter for specified modulus and adjusting parameter
+    pub const fn new(modulus: &[u64], adjuster: &[u64]) -> Self {
+        Self {
+            modulus: CInt::<62, L>(Self::convert::<64, 62, L>(modulus)),
+            adjuster: CInt::<62, L>(Self::convert::<64, 62, L>(adjuster)),
+            inverse: Self::inv(modulus[0]),
+        }
+    }
+
+    /// Returns either the adjusted modular multiplicative inverse for the argument or None
+    /// depending on invertibility of the argument, i.e. its coprimality with the modulus
+    pub fn invert<const S: usize>(&self, value: &[u64]) -> Option<[u64; S]> {
+        let (mut d, mut e) = (CInt::ZERO, self.adjuster.clone());
+        let mut g = CInt::<62, L>(Self::convert::<64, 62, L>(value));
+        let (mut delta, mut f) = (1, self.modulus.clone());
+        let mut matrix;
+        while g != CInt::ZERO {
+            (delta, matrix) = Self::jump(&f, &g, delta);
+            (f, g) = Self::fg(f, g, matrix);
+            (d, e) = self.de(d, e, matrix);
+        }
+        // At this point the absolute value of "f" equals the greatest common divisor
+        // of the integer to be inverted and the modulus the inverter was created for.
+        // Thus, if "f" is neither 1 nor -1, then the sought inverse does not exist
+        let antiunit = f == CInt::MINUS_ONE;
+        if (f != CInt::ONE) && !antiunit {
+            return None;
+        }
+        Some(Self::convert::<62, 64, S>(&self.norm(d, antiunit).0))
+    }
+}

--- a/src/ff_jacobi.rs
+++ b/src/ff_jacobi.rs
@@ -1,0 +1,415 @@
+use core::cmp::PartialEq;
+use std::ops::{Add, Mul, Neg, Shr, Sub};
+
+/// Big signed (64 * L)-bit integer type, whose variables store
+/// numbers in the two's complement code as arrays of 64-bit chunks.
+/// The ordering of the chunks in these arrays is little-endian.
+/// The arithmetic operations for this type are wrapping ones
+#[derive(Clone)]
+pub struct LInt<const L: usize>([u64; L]);
+
+impl<const L: usize> LInt<L> {
+    /// Representation of -1
+    pub const MINUS_ONE: Self = Self([u64::MAX; L]);
+
+    /// Representation of 0
+    pub const ZERO: Self = Self([0; L]);
+
+    /// Representation of 1
+    pub const ONE: Self = {
+        let mut data = [0; L];
+        data[0] = 1;
+        Self(data)
+    };
+
+    /// Returns the number, which is stored as the specified
+    /// sequence padded with zeros to length L. If the input
+    /// sequence is longer than L, the method panics
+    pub fn new(data: &[u64]) -> Self {
+        let mut number = Self::ZERO;
+        number.0[..data.len()].copy_from_slice(data);
+        number
+    }
+
+    /// Returns "true" iff the current number is negative
+    #[inline]
+    pub fn is_negative(&self) -> bool {
+        self.0[L - 1] > (u64::MAX >> 1)
+    }
+
+    /// Returns a tuple representing the sum of the first two arguments and the bit
+    /// described by the third argument. The first element of the tuple is this sum
+    /// modulo 2^64, the second one indicates whether the sum is no less than 2^64
+    #[inline]
+    fn sum(first: u64, second: u64, carry: bool) -> (u64, bool) {
+        // The implementation is inspired with the "carrying_add" function from this source:
+        // https://github.com/rust-lang/rust/blob/master/library/core/src/num/uint_macros.rs
+        let (second, carry) = second.overflowing_add(carry as u64);
+        let (first, high) = first.overflowing_add(second);
+        (first, carry || high)
+    }
+
+    /// Returns "(low, high)", where "high * 2^64 + low = first * second + carry + summand"
+    #[inline]
+    fn prodsum(first: u64, second: u64, summand: u64, carry: u64) -> (u64, u64) {
+        let all = (first as u128) * (second as u128) + (carry as u128) + (summand as u128);
+        (all as u64, (all >> u64::BITS) as u64)
+    }
+}
+
+impl<const L: usize> PartialEq for LInt<L> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<const L: usize> Shr<u32> for &LInt<L> {
+    type Output = LInt<L>;
+    /// Returns the result of applying the arithmetic right shift to the current number.
+    /// The specified bit quantity the number is shifted by must lie in {1, 2, ..., 63}.
+    /// For the quantities outside of the range, the behavior of the method is undefined
+    fn shr(self, bits: u32) -> Self::Output {
+        debug_assert!(
+            (bits > 0) && (bits < 64),
+            "Cannot shift by 0 or more than 63 bits!"
+        );
+        let (mut data, right) = ([0; L], u64::BITS - bits);
+        for i in 0..(L - 1) {
+            data[i] = (self.0[i] >> bits) | (self.0[i + 1] << right);
+        }
+        data[L - 1] = self.0[L - 1] >> bits;
+        if self.is_negative() {
+            data[L - 1] |= u64::MAX << right;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Shr<u32> for LInt<L> {
+    type Output = LInt<L>;
+    fn shr(self, bits: u32) -> Self::Output {
+        &self >> bits
+    }
+}
+
+impl<const L: usize> Add for &LInt<L> {
+    type Output = LInt<L>;
+    fn add(self, other: Self) -> Self::Output {
+        let (mut data, mut carry) = ([0; L], false);
+        for i in 0..L {
+            (data[i], carry) = Self::Output::sum(self.0[i], other.0[i], carry);
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Add<&LInt<L>> for LInt<L> {
+    type Output = LInt<L>;
+    fn add(self, other: &Self) -> Self::Output {
+        &self + other
+    }
+}
+
+impl<const L: usize> Add for LInt<L> {
+    type Output = LInt<L>;
+    fn add(self, other: Self) -> Self::Output {
+        &self + &other
+    }
+}
+
+impl<const L: usize> Sub for &LInt<L> {
+    type Output = LInt<L>;
+    fn sub(self, other: Self) -> Self::Output {
+        // For the two's complement code the additive negation is the result of
+        // adding 1 to the bitwise inverted argument's representation. Thus, for
+        // any encoded integers x and y we have x - y = x + !y + 1, where "!" is
+        // the bitwise inversion and addition is done according to the rules of
+        // the code. The algorithm below uses this formula and is the modified
+        // addition algorithm, where the carry flag is initialized with "true"
+        // and the chunks of the second argument are bitwise inverted
+        let (mut data, mut carry) = ([0; L], true);
+        for i in 0..L {
+            (data[i], carry) = Self::Output::sum(self.0[i], !other.0[i], carry);
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Sub<&LInt<L>> for LInt<L> {
+    type Output = LInt<L>;
+    fn sub(self, other: &Self) -> Self::Output {
+        &self - other
+    }
+}
+
+impl<const L: usize> Sub for LInt<L> {
+    type Output = LInt<L>;
+    fn sub(self, other: Self) -> Self::Output {
+        &self - &other
+    }
+}
+
+impl<const L: usize> Neg for &LInt<L> {
+    type Output = LInt<L>;
+    fn neg(self) -> Self::Output {
+        // For the two's complement code the additive negation is the result
+        // of adding 1 to the bitwise inverted argument's representation
+        let (mut data, mut carry) = ([0; L], true);
+        for i in 0..L {
+            (data[i], carry) = (!self.0[i]).overflowing_add(carry as u64);
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Neg for LInt<L> {
+    type Output = LInt<L>;
+    fn neg(self) -> Self::Output {
+        -&self
+    }
+}
+
+impl<const L: usize> Mul for &LInt<L> {
+    type Output = LInt<L>;
+    fn mul(self, other: Self) -> Self::Output {
+        let mut data = [0; L];
+        for i in 0..L {
+            let mut carry = 0;
+            for k in 0..(L - i) {
+                (data[i + k], carry) =
+                    Self::Output::prodsum(self.0[i], other.0[k], data[i + k], carry);
+            }
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Mul<&LInt<L>> for LInt<L> {
+    type Output = LInt<L>;
+    fn mul(self, other: &Self) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const L: usize> Mul for LInt<L> {
+    type Output = LInt<L>;
+    fn mul(self, other: Self) -> Self::Output {
+        &self * &other
+    }
+}
+
+impl<const L: usize> Mul<i64> for &LInt<L> {
+    type Output = LInt<L>;
+    fn mul(self, other: i64) -> Self::Output {
+        let mut data = [0; L];
+        // If the short multiplicand is non-negative, the standard multiplication
+        // algorithm is performed. Otherwise, the product of the additively negated
+        // multiplicands is found as follows. Since for the two's complement code
+        // the additive negation is the result of adding 1 to the bitwise inverted
+        // argument's representation, for any encoded integers x and y we have
+        // x * y = (-x) * (-y) = (!x + 1) * (-y) = !x * (-y) + (-y),  where "!" is
+        // the bitwise inversion and arithmetic operations are performed according
+        // to the rules of the code. If the short multiplicand is negative, the
+        // algorithm below uses this formula by substituting the short multiplicand
+        // for y and becomes the modified standard multiplication algorithm, where
+        // the carry variable is being initialized with the additively negated short
+        // multiplicand and the chunks of the long multiplicand are bitwise inverted
+        let (other, mut carry, mask) = if other < 0 {
+            (-other as u64, -other as u64, u64::MAX)
+        } else {
+            (other as u64, 0, 0)
+        };
+        for i in 0..L {
+            (data[i], carry) = Self::Output::prodsum(self.0[i] ^ mask, other, 0, carry);
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const L: usize> Mul<i64> for LInt<L> {
+    type Output = LInt<L>;
+    fn mul(self, other: i64) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const L: usize> Mul<&LInt<L>> for i64 {
+    type Output = LInt<L>;
+    fn mul(self, other: &LInt<L>) -> Self::Output {
+        other * self
+    }
+}
+
+impl<const L: usize> Mul<LInt<L>> for i64 {
+    type Output = LInt<L>;
+    fn mul(self, other: LInt<L>) -> Self::Output {
+        other * self
+    }
+}
+
+/// Returns the "approximations" of the arguments and the flag indicating whether
+/// both arguments are equal to their "approximations". Both the arguments must be
+/// non-negative, and at least one of them must be non-zero. For an incorrect input,
+/// the behavior of the function is undefined. These "approximations" are defined
+/// in the following way. Let n be the bit length of the largest argument without
+/// leading zeros. For n > 64 the "approximation" of the argument, which equals v,
+/// is (v div 2 ^ (n - 32)) * 2 ^ 32 + (v mod 2 ^ 32), i.e. it retains the high and
+/// low bits of the n-bit representation of v. If n does not exceed 64, an argument
+/// and its "approximation" are equal. These "approximations" are defined slightly
+/// differently from the ones in the Pornin's method for modular inversion: instead
+/// of taking the 33 high and 31 low bits of the n-bit representation of an argument,
+/// the 32 high and 32 low bits are taken
+fn approximate<const L: usize>(x: &LInt<L>, y: &LInt<L>) -> (u64, u64, bool) {
+    debug_assert!(
+        !(x.is_negative() || y.is_negative()),
+        "Both the arguments must be non-negative!"
+    );
+    debug_assert!(
+        (*x != LInt::ZERO) || (*y != LInt::ZERO),
+        "At least one argument must be non-zero!"
+    );
+    let mut i = L - 1;
+    while (x.0[i] == 0) && (y.0[i] == 0) {
+        i -= 1;
+    }
+    if i == 0 {
+        return (x.0[0], y.0[0], true);
+    }
+    let mut h = (x.0[i], y.0[i]);
+    let z = h.0.leading_zeros().min(h.1.leading_zeros());
+    h = (h.0 << z, h.1 << z);
+    if z > 32 {
+        h.0 |= x.0[i - 1] >> z;
+        h.1 |= y.0[i - 1] >> z;
+    }
+    let h = (h.0 & u64::MAX << 32, h.1 & u64::MAX << 32);
+    let l = (x.0[0] & u64::MAX >> 32, y.0[0] & u64::MAX >> 32);
+    (h.0 | l.0, h.1 | l.1, false)
+}
+
+/// Returns the Jacobi symbol ("n" / "d") multiplied by either 1 or -1.
+/// The later multiplicand is -1 iff the second-lowest bit of "t" is 1.
+/// The value of "d" must be odd in accordance with the Jacobi symbol
+/// definition. For even values of "d", the behavior is not defined.
+/// The implementation is based on the binary Euclidean algorithm
+fn jacobinary(mut n: u64, mut d: u64, mut t: u64) -> i64 {
+    debug_assert!(d & 1 > 0, "The second argument must be odd!");
+    while n != 0 {
+        if n & 1 > 0 {
+            if n < d {
+                (n, d) = (d, n);
+                t ^= n & d;
+            }
+            n = (n - d) >> 1;
+            t ^= d ^ d >> 1;
+        } else {
+            let z = n.trailing_zeros();
+            t ^= (d ^ d >> 1) & (z << 1) as u64;
+            n >>= z;
+        }
+    }
+    (d == 1) as i64 * (1 - (t & 2) as i64)
+}
+
+/// Returns the Jacobi symbol ("n" / "d") computed by means of the modification
+/// of the the Pornin's method for modular inversion. The arguments are unsigned
+/// big integers in the form of arrays of 64-bit chunks, the ordering of which
+/// is little-endian. The value of "d" must be odd in accordance with the Jacobi
+/// symbol definition. Both the arguments must be less than 2 ^ (64 * L - 31).
+/// For an incorrect input, the behavior of the function is undefined. The method
+/// differs from the Pornin's method for modular inversion in absence of the parts,
+/// which are not necessary to compute the greatest common divisor of arguments,
+/// presence of the parts used to compute the Jacobi symbol, which are based on
+/// the properties of the modified Jacobi symbol (x / |y|) described by M. Hamburg,
+/// and some original optimizations. Only these differences have been commented;
+/// the aforesaid Pornin's method and the used ideas of M. Hamburg were given here:
+/// - T. Pornin, "Optimized Binary GCD for Modular Inversion",
+/// https://eprint.iacr.org/2020/972.pdf
+/// - M. Hamburg, "Computing the Jacobi symbol using Bernstein-Yang",
+/// https://eprint.iacr.org/2021/1271.pdf
+pub fn jacobi<const L: usize>(n: &[u64], d: &[u64]) -> i64 {
+    // Instead of the variable "j" taking the values from {-1, 1} and satysfying
+    // at the end of the outer loop iteration the equation J = "j" * ("n" / |"d"|)
+    // for the modified Jacobi symbol ("n" / |"d"|) and the sought Jacobi symbol J,
+    // we store the sign bit of "j" in the second-lowest bit of "t" for optimization
+    // purposes. This approach was influenced by the paper by M. Hamburg
+    let (mut n, mut d, mut t) = (LInt::<L>::new(n), LInt::<L>::new(d), 0u64);
+    debug_assert!(d.0[0] & 1 > 0, "The second argument must be odd!");
+    debug_assert!(
+        n.0[L - 1].leading_zeros().min(d.0[L - 1].leading_zeros()) >= 31,
+        "Both the arguments must be less than 2 ^ (64 * L - 31)!"
+    );
+    loop {
+        // The inner loop performs 30 iterations instead of 31 ones in the aforementioned
+        // Pornin's method, and the "approximations" of "n" and "d" retain 32 of the lowest
+        // bits instead of 31 in that method. These modifications allow the values of the
+        // "approximation" variables to be equal modulo 8 to the corresponding "precise"
+        // variables' values, which would have been computed, if the "precise" variables
+        // had been updated in the inner loop along with the "approximations". This equality
+        // modulo 8 is used to update the second-lowest bit of "t" in accordance with the
+        // properties of the modified Jacobi symbol (x / |y|). The admissibility of these
+        // modifications has been proven using the appropriately modified Pornin's theorems
+        let (mut u, mut v, mut i) = ((1i64, 0i64), (0i64, 1i64), 30);
+        let (mut a, mut b, precise) = approximate(&n, &d);
+        // When each "approximation" variable has the same value as the corresponding "precise"
+        // one, the computation is accomplished using the short-arithmetic method of the Jacobi
+        // symbol calculation by means of the binary Euclidean algorithm. This approach aims at
+        // avoiding the parts of the final computations, which are related to long arithmetics
+        if precise {
+            return jacobinary(a, b, t);
+        }
+        while i > 0 {
+            if a & 1 > 0 {
+                if a < b {
+                    (a, b, u, v) = (b, a, v, u);
+                    // In both the aforesaid Pornin's method and its modification "n" and "d"
+                    // could not become negative simultaneously even if they were updated after
+                    // each iteration of the inner loop. Also at this point they both have odd
+                    // values. Therefore, the quadratic reciprocity law for the modified Jacobi
+                    // symbol (x / |y|) can be used. According to it, if both x and y are odd
+                    // numbers, among which there is a positive one, then for x = y = 3 (mod 4)
+                    // we have (x / |y|) = -(y / |x|) and for either x or y equal 1 modulo 4
+                    // the symbols (x / |y|) and (y / |x|) are equal
+                    t ^= a & b;
+                }
+                a = (a - b) >> 1;
+                u = (u.0 - v.0, u.1 - v.1);
+                v = (v.0 << 1, v.1 << 1);
+                // The modified Jacobi symbol (2 / |y|) is -1, iff y mod 8 is {3, 5}
+                t ^= b ^ b >> 1;
+                i -= 1;
+            } else {
+                // Performing the batch of sequential iterations, which divide "a" by 2
+                let z = i.min(a.trailing_zeros());
+                // The modified Jacobi symbol (2 / |y|) is -1, iff y mod 8 is {3, 5}. However,
+                // we do not need its value for a batch with an even number of divisions by 2
+                t ^= (b ^ b >> 1) & (z << 1) as u64;
+                v = (v.0 << z, v.1 << z);
+                a >>= z;
+                i -= z;
+            }
+        }
+        (n, d) = ((&n * u.0 + &d * u.1) >> 30, (&n * v.0 + &d * v.1) >> 30);
+
+        // This fragment is present to guarantee the correct behavior of the function
+        // in the case of arguments, whose greatest common divisor is no less than 2^64
+        if n == LInt::ZERO {
+            // In both the aforesaid Pornin's method and its modification the pair of the values
+            // of "n" and "d" after the divergence point contains a positive number and a negative
+            // one. Since the value of "n" is 0, the divergence point has not been reached by the
+            // inner loop this time, so there is no need to check whether "d" is equal to -1
+            return (d == LInt::ONE) as i64 * (1 - (t & 2) as i64);
+        }
+
+        if n.is_negative() {
+            // Since in both the aforesaid Pornin's method and its modification "d" is always odd
+            // and cannot become negative simultaneously with "n", the value of "d" is positive.
+            // The modified Jacobi symbol (-1 / |y|) for a positive y is -1, iff y mod 4 = 3
+            t ^= d.0[0];
+            n = -n;
+        } else if d.is_negative() {
+            // The modified Jacobi symbols (x / |y|) and (x / |-y|) are equal, so "t" is not updated
+            d = -d;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod arithmetic;
 mod ff_inverse;
+mod ff_jacobi;
 pub mod fft;
 pub mod hash_to_curve;
 // TODO: remove this and use traits defined in axiom_pairing instead.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 mod arithmetic;
+mod ff_inverse;
+pub mod fft;
 pub mod hash_to_curve;
 // TODO: remove this and use traits defined in axiom_pairing instead.
 pub mod pairing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod arithmetic;
 mod ff_inverse;
 mod ff_jacobi;
-pub mod fft;
+
 pub mod hash_to_curve;
 // TODO: remove this and use traits defined in axiom_pairing instead.
 pub mod pairing;

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -179,17 +179,10 @@ impl ff::Field for Fp {
         CtOption::new(tmp, tmp.square().ct_eq(self))
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xfffffffefffffc2d,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -179,17 +179,10 @@ impl ff::Field for Fq {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xbfd25e8cd036413f,
-            0xbaaedce6af48a03b,
-            0xfffffffffffffffe,
-            0xffffffffffffffff,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -197,17 +197,10 @@ impl ff::Field for Fp {
         CtOption::new(tmp, tmp.square().ct_eq(self))
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xfffffffffffffffd,
-            0x00000000ffffffff,
-            0x0000000000000000,
-            0xffffffff00000001,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -174,17 +174,10 @@ impl ff::Field for Fq {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
     fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xf3b9cac2fc63254f,
-            0xbce6faada7179e84,
-            0xffffffffffffffff,
-            0xffffffff00000000,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
+        self.invert()
     }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {


### PR DESCRIPTION
## Description:
From snarkify merkle circuit example ([comparison](https://gist.github.com/cyphersnake/99dc030c2dea0793dba3c213d7e8128e)), 
we find that the performance of the poseidon hash in the Scroll version has a gap compared to the upstream.

- [MerkleTreeUpdateChip::new(proof.clone())](https://github.com/snarkify/sirius//blob/285-benchmark-scroll-v1.1/examples/merkle/circuit.rs#L174)
    - [assert!(proof.verify());](https://github.com/snarkify/sirius//blob/285-benchmark-scroll-v1.1/examples/merkle/merkle_tree_gadget/chip.rs#L29)
        - [hash(old, *right), hash(new, *right)](https://github.com/snarkify/sirius//blob/285-benchmark-scroll-v1.1/examples/merkle/merkle_tree_gadget/off_circuit.rs#L234)
            - [Spec::new()](https://github.com/privacy-scaling-explorations/poseidon/blob/main/src/spec.rs#L309)

And it turns out that the [inverse()](https://github.com/scroll-tech/poseidon/blob/main/src/matrix.rs#L103-L116) operation is the main bottleneck.

## related PR
This PR cherry-picked several performance-optimizing PRs from upstream:
- privacy-scaling-explorations/halo2curves#83
- privacy-scaling-explorations/halo2curves#95

## performance
before
```
Start: kzg k_table_size=18 repeat_count=10
··Start: keygen
··End: keygen............................................................175.00s
··Start: prove
··End: prove.............................................................106.00s
··Start: verify
··End: verify..............................................................0.01s
End: kzg k_table_size=18 repeat_count=10.................................290.00s
```

after
```
Start: kzg k_table_size=18 repeat_count=10
··Start: keygen
··End: keygen.............................................................40.40s
··Start: prove
··End: prove..............................................................38.80s
··Start: verify
··End: verify..............................................................0.01s
End: kzg k_table_size=18 repeat_count=10..................................89.10s
```
